### PR TITLE
Add only latest version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The `setup` function accepts an options table which defaults to:
 {
   ignore = {},
   only_semantic_versions = false,
+  only_latest_version = false
 }
 ```
 
@@ -53,6 +54,7 @@ The `setup` function accepts an options table which defaults to:
 e.g. `ignore = { 'beta', 'rc' }`.
 - `only_semantic_versions` (Boolean): If `true`, will filter out all versions which don't follow 
   the `major.minor.patch` schema.
+- `only_latest_version` (Boolean): If `true`, will only show latest release version.
 
 
 ## Limitations

--- a/lua/cmp-npm/init.lua
+++ b/lua/cmp-npm/init.lua
@@ -44,12 +44,14 @@ function source:complete(params, callback)
           on_exit = function(job)
             local result = job:result()
             local version = result[1]
-            local versions = {
-              { label = version },
-              { label = "^" .. version },
-              { label = "~" .. version }
-            }
-            callback(versions)
+            if version then
+              local versions = {
+                { label = version },
+                { label = "^" .. version },
+                { label = "~" .. version }
+              }
+              callback(versions)
+            end
           end
       }):start()
     else Job

--- a/lua/cmp-npm/init.lua
+++ b/lua/cmp-npm/init.lua
@@ -4,6 +4,7 @@ local source = {}
 local opts = {
   ignore = {},
   only_semantic_versions = false,
+  only_latest_version = false
 }
 
 source.new = function()
@@ -33,7 +34,25 @@ function source:complete(params, callback)
   end
   if name == nil then return end
   if find_version then
+    if opts.only_latest_version then
     Job
+      :new({
+          "npm",
+          "info",
+          name,
+          "version",
+          on_exit = function(job)
+            local result = job:result()
+            local version = result[1]
+            local versions = {
+              { label = version },
+              { label = "^" .. version },
+              { label = "~" .. version }
+            }
+            callback(versions)
+          end
+      }):start()
+    else Job
       :new({
           "npm",
           "info",
@@ -74,6 +93,7 @@ function source:complete(params, callback)
             callback(items)
           end
       }):start()
+    end
   else
     Job
       :new({


### PR DESCRIPTION
Closes #8 

The simplest possible solution I could come up with. Testet locally and seems to work just fine.
I think overruling the other flags is ok, since no rc/beta version etc is shown with this command, just latest regular version.