### PR TITLE
Add get_trigger_characters() to fix completion issue

### DIFF
--- a/lua/cmp-npm/init.lua
+++ b/lua/cmp-npm/init.lua
@@ -17,6 +17,10 @@ function source:is_available()
   return filename == "package.json"
 end
 
+function source:get_trigger_characters()
+	return { '"' }
+end
+
 function source:get_debug_name()
   return 'npm'
 end


### PR DESCRIPTION
This fixes an issue where nvim-cmp will not call complete() as expected when cursor is on a double quote.

Without this change:

https://github.com/David-Kunz/cmp-npm/assets/62300817/b89edc83-c181-455c-b41f-8df80ffd9667

With this change:

https://github.com/David-Kunz/cmp-npm/assets/62300817/566aa0a2-119c-490b-88b7-9a7f45039824

